### PR TITLE
Updated default rpc port to the number specified in the README.

### DIFF
--- a/dapp/src/lib/web3Service.js
+++ b/dapp/src/lib/web3Service.js
@@ -9,7 +9,7 @@ export const getProvider = (networkId) => {
     case '42':
       return 'https://kovan.infura.io/';
     default:
-      return 'http://localhost:3000/';
+      return 'http://localhost:8545/';
   }
 }
 


### PR DESCRIPTION
In the readme under "How to test" the gnache server is set to port 8545. The library that grabs the rpc return 3000. Changing this to 8545 allows for interaction with the deployed contracts.

It looks like local users will also need to update the contract addresses in this file. Do you want to add instructions to the readme for that?